### PR TITLE
Use Locale.ROOT in toLowerCase() calls

### DIFF
--- a/src/main/java/org/wildfly/maven/plugins/licenses/KnownLicense.java
+++ b/src/main/java/org/wildfly/maven/plugins/licenses/KnownLicense.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.maven.model.License;
@@ -121,8 +122,8 @@ public enum KnownLicense {
     public static Map<String, License> toMap() {
         Map<String, License> licenses = new HashMap<>();
         Arrays.stream(KnownLicense.values()).forEach(k -> {
-            licenses.put(k.name.toLowerCase(), k.license);
-            k.aliases.forEach(a -> licenses.put(a.toLowerCase(), k.license));
+            licenses.put(k.name.toLowerCase(Locale.ROOT), k.license);
+            k.aliases.forEach(a -> licenses.put(a.toLowerCase(Locale.ROOT), k.license));
         });
 
         return Collections.unmodifiableMap(licenses);

--- a/src/main/java/org/wildfly/maven/plugins/licenses/UpdateLicensesMojo.java
+++ b/src/main/java/org/wildfly/maven/plugins/licenses/UpdateLicensesMojo.java
@@ -26,6 +26,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
@@ -282,7 +283,7 @@ public class UpdateLicensesMojo
         if (!declaredLicenses.isEmpty()) {
           for (int i = 0; i < declaredLicenses.size(); i++) {
             License license = declaredLicenses.get(i);
-            String licenseName = license.getName().toLowerCase();
+            String licenseName = license.getName().toLowerCase(Locale.ROOT);
             License canonicalLicense = knownLicenses.containsKey(licenseName) ? knownLicenses.get(licenseName)
                     : licenseAliasesMap.get(licenseName);
             if (canonicalLicense != null) {
@@ -446,9 +447,9 @@ public class UpdateLicensesMojo
         }
       }
       for (KnownLicenseInfo knownLicenseInfo : projectInfo.getKnownLicensesList()) {
-        licenseAliasesMap.put(knownLicenseInfo.getLicense().getName().toLowerCase(), knownLicenseInfo.getLicense());
+        licenseAliasesMap.put(knownLicenseInfo.getLicense().getName().toLowerCase(Locale.ROOT), knownLicenseInfo.getLicense());
         for (String alias : knownLicenseInfo.getAliases()) {
-          licenseAliasesMap.put(alias.toLowerCase(), knownLicenseInfo.getLicense());
+          licenseAliasesMap.put(alias.toLowerCase(Locale.ROOT), knownLicenseInfo.getLicense());
         }
       }
     } catch (Exception e) {


### PR DESCRIPTION
## Summary
- Add `Locale.ROOT` parameter to all `toLowerCase()` calls in `KnownLicense` and `UpdateLicensesMojo`
- Follows best practice for locale-independent string operations

Fixes #12